### PR TITLE
Add 'Citation' section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ This section highlights notebooks that provide utility functions or demonstrate 
 Portions of this project were developed with the assistance of Google AI (Jules).
 The underlying concepts for protein sequence generation draw inspiration from the original ProtGPT2 work and the Hugging Face Transformers library.
 
+## Citation
+If you use the software in this repository, please cite the following research article:
+[https://www.mdpi.com/2073-8994/14/11/2274](https://www.mdpi.com/2073-8994/14/11/2274)
+
 ## License
 These code files are for examples on creating a generative model for protein sequence data. They may be expanded upon as described in the LICENSE file (Apache License v2.0). This license is identical to the Huggingface transformers API. It is an open-source and permissive software license.
 


### PR DESCRIPTION
This commit adds a new 'Citation' section to the README.md file. It requests you to cite the research article https://www.mdpi.com/2073-8994/14/11/2274 if you use the software from this repository.